### PR TITLE
Set the logrotate filetype for /etc/logrotate.conf

### DIFF
--- a/ftdetect/logrotate.vim
+++ b/ftdetect/logrotate.vim
@@ -1,1 +1,1 @@
-autocmd BufNewFile,BufRead /etc/logrotate.d/* set filetype=logrotate
+autocmd BufNewFile,BufRead /etc/logrotate.[dc]* set filetype=logrotate


### PR DESCRIPTION
Use `/etc/logrotate.[dc]*` as the auto-command pattern for matching
filenames when starting to edit a buffer. This pattern matches
`/etc/logrotate.conf` as well as configuration files in the
`/etc/logrotate.d` directory.